### PR TITLE
fvのpタグをh1タグに変更（SEO対策）

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,11 @@
             <div class="fv__content">
 
                 <div class="fv__info">
-                    <p class="fv__info_catch">
+                    <!-- h1を設定 -->
+                    <h1 class="fv__info_catch">
                         <span class="fv__info_catch_l">PC・スマートフォン</span>で<br>
                         いつでも好きな時間に学習
-                    </p>
+                    </h1>
                     <p class="fv__cost">
                         <span class="fv__cost_vertical">月額</span><span class="fv__cost_num"><span class="fv__cost_num-tight">17</span>,000</span><span class="fv__cost_small">円</span>
                     </p>


### PR DESCRIPTION
トップページのメインキャッチコピー部分を  
`<p>`から`<h1>`に変更しました。  
SEO効果と文書構造の意味付けを改善しています。
